### PR TITLE
Fix for inability to play singleplayer after making modId field blank.

### DIFF
--- a/src/main/java/ehacks/mod/main/Main.java
+++ b/src/main/java/ehacks/mod/main/Main.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import net.minecraft.client.Minecraft;
 import net.minecraftforge.common.MinecraftForge;
 
-@Mod(modid = "EHacks", name = "EHacks", version = "4.1.9")
+@Mod(modid = "EHacks", name = "EHacks", version = "4.1.9", acceptableRemoteVersions = "*")
 public class Main {
 
     @Mod.Instance(value = "EHacks")


### PR DESCRIPTION
After changing the ModID to blank, you are no longer able to play singleplayer. Each time you try, the client local server thinks you are missing a mod. You will be greeted with a message similar to the following:

Player109 lost connection: TextComponent{text='Mod rejections [FMLMod:EHacks{4.1.9}]', siblings=[], style=Style{hasParent=false, color=null, bold=null, italic=null, underlined=null, obfuscated=null, clickEvent=null, hoverEvent=null}}

You need to go back and reset the ModID. Allowing all acceptable remote versions fixes this issue.